### PR TITLE
Add bugfix related to the PicMessages

### DIFF
--- a/app/src/main/java/com/github/brugapp/brug/ui/ChatActivity.kt
+++ b/app/src/main/java/com/github/brugapp/brug/ui/ChatActivity.kt
@@ -274,21 +274,5 @@ class ChatActivity : AppCompatActivity() {
                 viewModel.sendPicMessage(this, convID, viewModel.getImageUri())
             }
         }
-
-//        if (requestCode == TAKE_PICTURE_REQUEST_CODE && resultCode == RESULT_OK) {
-//
-//
-//
-//        } else if (requestCode == SELECT_PICTURE_REQUEST_CODE && resultCode == RESULT_OK) {
-//
-//        }
-//
-//        val imageUri = data!!.data ?: Uri.parse(data.extras?.getString(PIC_ATTACHMENT_INTENT_KEY))
-//        if (imageUri != null) {
-//            // this will be the case for the gallery image
-//            // camera images returns null as extras
-//            println("=== URI set ===")
-//            viewModel.sendPicMessage(this, convID, imageUri)
-//        }
     }
 }

--- a/app/src/main/java/com/github/brugapp/brug/ui/ChatActivity.kt
+++ b/app/src/main/java/com/github/brugapp/brug/ui/ChatActivity.kt
@@ -23,7 +23,6 @@ import com.github.brugapp.brug.R
 import com.github.brugapp.brug.SELECT_PICTURE_REQUEST_CODE
 import com.github.brugapp.brug.TAKE_PICTURE_REQUEST_CODE
 import com.github.brugapp.brug.model.Conversation
-import com.github.brugapp.brug.model.Message
 import com.github.brugapp.brug.model.message_types.AudioMessage
 import com.github.brugapp.brug.model.message_types.TextMessage
 import com.github.brugapp.brug.model.services.DateService
@@ -265,12 +264,12 @@ class ChatActivity : AppCompatActivity() {
             Toast.makeText(this, "Image selected", Toast.LENGTH_SHORT).show()
         }
 
-        val imageUri = data?.extras?.getString(PIC_ATTACHMENT_INTENT_KEY)
+        val imageUri = data!!.data ?: Uri.parse(data.extras?.getString(PIC_ATTACHMENT_INTENT_KEY))
         if (imageUri != null) {
             // this will be the case for the gallery image
             // camera images returns null as extras
             println("=== URI set ===")
-            viewModel.sendPicMessage(this, convID, Uri.parse(imageUri))
+            viewModel.sendPicMessage(this, convID, imageUri)
         }
     }
 }

--- a/app/src/main/java/com/github/brugapp/brug/ui/ChatActivity.kt
+++ b/app/src/main/java/com/github/brugapp/brug/ui/ChatActivity.kt
@@ -258,18 +258,37 @@ class ChatActivity : AppCompatActivity() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
 
-        if (requestCode == TAKE_PICTURE_REQUEST_CODE && resultCode == RESULT_OK) {
-            Toast.makeText(this, "Image taken", Toast.LENGTH_SHORT).show()
-        } else if (requestCode == SELECT_PICTURE_REQUEST_CODE && resultCode == RESULT_OK) {
-            Toast.makeText(this, "Image selected", Toast.LENGTH_SHORT).show()
+        if (resultCode == RESULT_OK){
+            if (requestCode == SELECT_PICTURE_REQUEST_CODE){
+                Toast.makeText(this, "Image selected", Toast.LENGTH_SHORT).show()
+                val imageUri = data!!.data ?: Uri.parse(data.extras?.getString(PIC_ATTACHMENT_INTENT_KEY))
+                viewModel.setImageUri(imageUri)
+                viewModel.sendPicMessage(this, convID, viewModel.getImageUri())
+            }
+            else if (requestCode == TAKE_PICTURE_REQUEST_CODE){
+                Toast.makeText(this, "Image taken", Toast.LENGTH_SHORT).show()
+                if(data!!.extras != null){
+                    val imageUri = Uri.parse(data.extras?.getString(PIC_ATTACHMENT_INTENT_KEY))
+                    viewModel.setImageUri(imageUri)
+                }
+                viewModel.sendPicMessage(this, convID, viewModel.getImageUri())
+            }
         }
 
-        val imageUri = data!!.data ?: Uri.parse(data.extras?.getString(PIC_ATTACHMENT_INTENT_KEY))
-        if (imageUri != null) {
-            // this will be the case for the gallery image
-            // camera images returns null as extras
-            println("=== URI set ===")
-            viewModel.sendPicMessage(this, convID, imageUri)
-        }
+//        if (requestCode == TAKE_PICTURE_REQUEST_CODE && resultCode == RESULT_OK) {
+//
+//
+//
+//        } else if (requestCode == SELECT_PICTURE_REQUEST_CODE && resultCode == RESULT_OK) {
+//
+//        }
+//
+//        val imageUri = data!!.data ?: Uri.parse(data.extras?.getString(PIC_ATTACHMENT_INTENT_KEY))
+//        if (imageUri != null) {
+//            // this will be the case for the gallery image
+//            // camera images returns null as extras
+//            println("=== URI set ===")
+//            viewModel.sendPicMessage(this, convID, imageUri)
+//        }
     }
 }

--- a/app/src/main/java/com/github/brugapp/brug/view_model/ChatViewModel.kt
+++ b/app/src/main/java/com/github/brugapp/brug/view_model/ChatViewModel.kt
@@ -58,7 +58,7 @@ class ChatViewModel : ViewModel() {
 
     fun initViewModel(messages: MutableList<Message>) {
         this.messages = messages
-        this.adapter = ChatMessagesListAdapter(messages)
+        this.adapter = ChatMessagesListAdapter(this, messages)
     }
 
     fun getAdapter(): ChatMessagesListAdapter {
@@ -113,7 +113,7 @@ class ChatViewModel : ViewModel() {
             "Me",
             DateService.fromLocalDateTime(LocalDateTime.now()),
             textBox.text.toString(),
-            picURI.toString()
+            compressImage(activity, picURI).toString()
         )
 
         sendMessage(newMessage, convID, activity)
@@ -161,7 +161,7 @@ class ChatViewModel : ViewModel() {
         return image
     }
 
-    private fun resize(activity: ChatActivity, uri: Uri): URI {
+    private fun compressImage(activity: ChatActivity, uri: Uri): URI {
         // open the image and resize it
         val imageBM = uriToBitmap(activity, uri)
         val resized = Bitmap.createScaledBitmap(imageBM, 500, 500, false)

--- a/app/src/main/java/com/github/brugapp/brug/view_model/ChatViewModel.kt
+++ b/app/src/main/java/com/github/brugapp/brug/view_model/ChatViewModel.kt
@@ -50,6 +50,7 @@ class ChatViewModel : ViewModel() {
     private lateinit var adapter: ChatMessagesListAdapter
     private lateinit var mediaRecorder : MediaRecorder
     private lateinit var audioPath : String
+    private lateinit var imageUri: Uri // NEEDED TO RETRIEVE THE IMAGE FROM THE CAMERA AFTER SNAPPING A PICTURE
 
     //TODO: Remove initial init. and revert to lateinit var
     private var messages: MutableList<Message> = mutableListOf()
@@ -66,7 +67,6 @@ class ChatViewModel : ViewModel() {
     }
 
     fun sendMessage(message: Message, convID: String, activity: ChatActivity) {
-//        val newMessage = Message("Me", DateService.fromLocalDateTime(LocalDateTime.now()), content)
         messages.add(message)
         adapter.notifyItemInserted(messages.size - 1)
         // scroll to bottom automatically
@@ -128,7 +128,7 @@ class ChatViewModel : ViewModel() {
         if (intent.resolveActivity(activity.packageManager) != null) {
             val imageFile = createImageFile(activity)
             // Create a file Uri for saving the image
-            val imageUri = FileProvider.getUriForFile(
+            imageUri = FileProvider.getUriForFile(
                 activity,
                 "com.github.brugapp.brug.fileprovider",
                 imageFile
@@ -136,6 +136,14 @@ class ChatViewModel : ViewModel() {
             intent.putExtra(MediaStore.EXTRA_OUTPUT, imageUri)
             startActivityForResult(activity, intent, TAKE_PICTURE_REQUEST_CODE, null)
         }
+    }
+
+    fun getImageUri(): Uri {
+        return this.imageUri
+    }
+
+    fun setImageUri(uri: Uri){
+        imageUri = uri
     }
 
     fun selectGalleryImage(activity: ChatActivity) {


### PR DESCRIPTION
This PR aims at fixing a bug found by @DeepGreen1, where a message containing a picture would not send itself in the chat.
The culprit was on line 267, where the imageUri variable wasn't properly initialized, leading to an empty Uri when the user requested an image to be sent from the Gallery or the Camera.

EDIT: Another bug regarding the way the images were displayed has been fixed in the last commit, due to a missing call to the resize/compress function. 
EDIT2: Finally fixed the issue with the Camera, the culprit was lying in the onActivityResult method and was due to a weird behavior with the Camera, which didn't return the correct Uri and left the requested field as null instead after taking a picture. 