### PR TITLE
Fixed audio messages crash when sent

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,10 +70,6 @@ dependencies {
     def lifecycle_version = "2.5.0-alpha05"
     def arch_version = "2.1.0"
 
-    //for AppCompat use:
-    //appcompat v26+ is highly recommended to support older APIs
-    //implementation 'com.devlomi.record-view:record-view:2.0.1'
-
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.github.JagarYousef:ChatVoicePlayer:1.1.0'
 

--- a/app/src/androidTest/java/com/github/brugapp/brug/ChatActivityTest.kt
+++ b/app/src/androidTest/java/com/github/brugapp/brug/ChatActivityTest.kt
@@ -262,26 +262,6 @@ class ChatActivityTest {
         }
     }
 
-/*=======
-    fun sendCameraMessageOpensCamera() {
->>>>>>> main
-        val context = ApplicationProvider.getApplicationContext<Context>()
-
-        val intent = Intent(context, ChatActivity::class.java).apply {
-            putExtra(CHAT_INTENT_KEY, conversation)
-        }
-
-<<<<<<< HEAD
-        val message = "Test text"
-
-=======
-        ActivityScenario.launch<Activity>(intent).use {
-            val expectedIntent: Matcher<Intent> = allOf(hasAction(MediaStore.ACTION_IMAGE_CAPTURE))
-            onView(withId(R.id.buttonSendImagePerCamera)).perform(click())
-            intended(expectedIntent)
-        }
-    }*/
-
     @Test
     fun sendCameraMessageOpensCamera() {
         val context = ApplicationProvider.getApplicationContext<Context>()

--- a/app/src/androidTest/java/com/github/brugapp/brug/MessageRepositoryTest.kt
+++ b/app/src/androidTest/java/com/github/brugapp/brug/MessageRepositoryTest.kt
@@ -56,7 +56,7 @@ private val AUDIOMSG = AudioMessage(
     USER2.getFullName(),
     DateService.fromLocalDateTime(LocalDateTime.now()),
     "LocationMessage",
-    "")
+    "","")
 
 
 class MessageRepositoryTest {

--- a/app/src/main/java/com/github/brugapp/brug/data/MessageRepository.kt
+++ b/app/src/main/java/com/github/brugapp/brug/data/MessageRepository.kt
@@ -111,6 +111,7 @@ object MessageRepository {
 
             snapshot.contains("audio_url") ->
                 AudioMessage.fromMessage(message,
+                    downloadFileToTemp(snapshot["audio_url"] as String).toString(),
                     downloadFileToTemp(snapshot["audio_url"] as String).toString()
                 )
             else -> TextMessage.fromMessage(message)

--- a/app/src/main/java/com/github/brugapp/brug/model/ChatMessagesListAdapter.kt
+++ b/app/src/main/java/com/github/brugapp/brug/model/ChatMessagesListAdapter.kt
@@ -119,7 +119,7 @@ class ChatMessagesListAdapter(private val viewModel: ChatViewModel, private val 
         }
 
         private fun bindAudioMessage(message: AudioMessage) {
-            itemView.findViewById<VoicePlayerView>(R.id.voicePlayerView).setAudio(message.audioUrl)
+            itemView.findViewById<VoicePlayerView>(R.id.voicePlayerView).setAudio(message.audioPath)
         }
 
         private fun resizeImage(uri: Uri): Uri {

--- a/app/src/main/java/com/github/brugapp/brug/model/message_types/AudioMessage.kt
+++ b/app/src/main/java/com/github/brugapp/brug/model/message_types/AudioMessage.kt
@@ -7,16 +7,18 @@ data class AudioMessage(
     override val senderName: String,
     override val timestamp: DateService,
     override val body: String,
-    val audioUrl: String)
+    val audioUrl: String,
+    val audioPath: String)
     : Message(senderName, timestamp, body){
 
     companion object {
-        fun fromMessage(m: Message, audioUrl: String): AudioMessage {
+        fun fromMessage(m: Message, audioUrl: String, audioPath: String): AudioMessage {
             return AudioMessage(
                 m.senderName,
                 m.timestamp,
                 m.body,
-                audioUrl
+                audioUrl,
+                audioPath
             )
         }
     }

--- a/app/src/main/java/com/github/brugapp/brug/ui/ChatActivity.kt
+++ b/app/src/main/java/com/github/brugapp/brug/ui/ChatActivity.kt
@@ -21,7 +21,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.FileProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.devlomi.record_view.RecordButton
 import com.github.brugapp.brug.PIC_ATTACHMENT_INTENT_KEY
 import com.github.brugapp.brug.R
 import com.github.brugapp.brug.SELECT_PICTURE_REQUEST_CODE
@@ -49,7 +48,7 @@ class ChatActivity : AppCompatActivity() {
     private lateinit var convID: String
 
     private lateinit var buttonSendTextMessage: ImageButton
-    private lateinit var recordButton: RecordButton
+    private lateinit var recordButton: ImageButton
     private lateinit var messageLayout: LinearLayout
     private lateinit var audioRecMessage: TextView
     private lateinit var buttonSendAudio: ImageButton
@@ -82,7 +81,6 @@ class ChatActivity : AppCompatActivity() {
         buttonSendAudio = findViewById(R.id.buttonSendAudio)
 
         recordButton = findViewById(R.id.recordButton)
-        viewModel.setListenForRecord(recordButton, false)
         initRecordButton(viewModel)
 
         deleteAudio = findViewById(R.id.deleteAudio)
@@ -193,11 +191,9 @@ class ChatActivity : AppCompatActivity() {
     private fun initRecordButton(model: ChatViewModel) {
         recordButton.setOnClickListener {
 
-            model.setListenForRecord(recordButton, true)
-
             if (model.isAudioPermissionOk(this) && model.isExtStorageOk(this)) {
 
-                model.setupRecording()
+                model.setupRecording(this)
 
                 messageLayout.visibility = View.GONE
                 recordButton.visibility = View.GONE
@@ -225,7 +221,6 @@ class ChatActivity : AppCompatActivity() {
             audioRecMessage.visibility = View.GONE
             messageLayout.visibility = View.VISIBLE
             recordButton.visibility = View.VISIBLE
-            model.setListenForRecord(recordButton, false)
         }
     }
 
@@ -238,7 +233,6 @@ class ChatActivity : AppCompatActivity() {
             audioRecMessage.visibility = View.GONE
             messageLayout.visibility = View.VISIBLE
             recordButton.visibility = View.VISIBLE
-            model.setListenForRecord(recordButton, false)
 
             model.sendAudio()
         }

--- a/app/src/main/java/com/github/brugapp/brug/ui/ChatActivity.kt
+++ b/app/src/main/java/com/github/brugapp/brug/ui/ChatActivity.kt
@@ -176,18 +176,6 @@ class ChatActivity : AppCompatActivity() {
             PackageManager.FEATURE_MICROPHONE)
     }*/
 
-
-    /*override fun onRequestPermissionsResult( // This should go to the bottom with the same function
-        requestCode: Int,
-        permissions: Array<out String>,
-        grantResults: IntArray
-    ) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if(requestCode == RECORDING_REQUEST_CODE){
-            recordButton.isEnabled = true
-        }
-    }*/
-
     private fun initRecordButton(model: ChatViewModel) {
         recordButton.setOnClickListener {
 
@@ -234,7 +222,7 @@ class ChatActivity : AppCompatActivity() {
             messageLayout.visibility = View.VISIBLE
             recordButton.visibility = View.VISIBLE
 
-            model.sendAudio()
+            model.sendAudio(this, convID)
         }
     }
 

--- a/app/src/main/java/com/github/brugapp/brug/ui/ChatActivity.kt
+++ b/app/src/main/java/com/github/brugapp/brug/ui/ChatActivity.kt
@@ -250,7 +250,7 @@ class ChatActivity : AppCompatActivity() {
             messageLayout.visibility = View.VISIBLE
             recordButton.visibility = View.VISIBLE
 
-            model.sendAudio(this, convID)
+            model.sendAudio(this, convID, firestore, firebaseAuth, firebaseStorage)
         }
     }
 

--- a/app/src/main/java/com/github/brugapp/brug/view_model/AddItemViewModel.kt
+++ b/app/src/main/java/com/github/brugapp/brug/view_model/AddItemViewModel.kt
@@ -12,20 +12,7 @@ class AddItemViewModel : ViewModel() {
         //checking if the item's name is valid (i.e non-empty)
         nameHelperText.text = validName(itemNameView)
 
-        if(nameHelperText.text.isNotEmpty()){
-
-            /* Alert window pops up to explain that name is invalid
-            Currently commented to make testing easier
-            AlertDialog.Builder(this)
-                .setTitle("Invalid Name")
-                .setMessage(nameHelperText.text)
-                .setPositiveButton("Continue"){ _,_ ->
-                }
-                .show()*/
-            return false
-        }
-
-        return true
+        return nameHelperText.text.isEmpty()
     }
 
     private fun validName(itemNameView : EditText): String {

--- a/app/src/main/java/com/github/brugapp/brug/view_model/ChatViewModel.kt
+++ b/app/src/main/java/com/github/brugapp/brug/view_model/ChatViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.brugapp.brug.view_model
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -12,12 +13,10 @@ import android.location.LocationManager
 import android.media.MediaPlayer
 import android.media.MediaRecorder
 import android.net.Uri
-import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
 import android.util.Log
 import android.widget.TextView
-import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityCompat.requestPermissions
 import androidx.core.app.ActivityCompat.startActivityForResult
@@ -25,7 +24,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.liveData
-import com.devlomi.record_view.RecordButton
 import com.github.brugapp.brug.*
 import com.github.brugapp.brug.data.MessageRepository
 import com.github.brugapp.brug.model.ChatMessagesListAdapter
@@ -230,6 +228,7 @@ class ChatViewModel() : ViewModel() {
         return outputFile.toURI()
     }
 
+    @SuppressLint("MissingPermission")
     fun requestLocation(
         convID: String,
         activity: ChatActivity,
@@ -265,9 +264,9 @@ class ChatViewModel() : ViewModel() {
         }
     }
 
-    fun setupRecording(){
+    fun setupRecording(activity: ChatActivity){
 
-        audioPath = Environment.getExternalStorageDirectory().absolutePath + "/Documents/audio.3gp"
+        audioPath = activity.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS)!!.absolutePath + "/audio.3gp"
 
         try {
             mediaRecorder = MediaRecorder()
@@ -281,10 +280,6 @@ class ChatViewModel() : ViewModel() {
         } catch (e: Exception) {
             e.printStackTrace()
         }
-    }
-
-    fun setListenForRecord(recordButton : RecordButton, bool : Boolean){
-        recordButton.isListenForRecord = bool
     }
 
     fun deleteAudio(){

--- a/app/src/main/java/com/github/brugapp/brug/view_model/ChatViewModel.kt
+++ b/app/src/main/java/com/github/brugapp/brug/view_model/ChatViewModel.kt
@@ -370,7 +370,6 @@ class ChatViewModel : ViewModel() {
         val audioMessage = AudioMessage("Me", DateService.fromLocalDateTime(LocalDateTime.now()),
             "Audio", Uri.fromFile(File(audioPath)).toString(), audioPath
         )
-        //Uri.fromFile(File(audioPath)).toString()
         sendMessage(audioMessage, convID, activity, firestore, firebaseAuth, firebaseStorage)
     }
 

--- a/app/src/main/java/com/github/brugapp/brug/view_model/ChatViewModel.kt
+++ b/app/src/main/java/com/github/brugapp/brug/view_model/ChatViewModel.kt
@@ -86,7 +86,7 @@ class ChatViewModel() : ViewModel() {
         activity.scrollToBottom(adapter.itemCount - 1)
 
         if(Firebase.auth.currentUser == null){
-            Snackbar.make(activity.findViewById(android.R.id.content),
+            Snackbar.make( activity.findViewById(android.R.id.content),
                 "ERROR: You are no longer logged in ! Log in again to send the message.",
                 Snackbar.LENGTH_LONG)
                 .show()
@@ -266,7 +266,8 @@ class ChatViewModel() : ViewModel() {
 
     fun setupRecording(activity: ChatActivity){
 
-        audioPath = activity.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS)!!.absolutePath + "/audio.3gp"
+        audioPath = activity.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS)!!.absolutePath +
+                "/audio" + DateService.fromLocalDateTime(LocalDateTime.now()) + ".3gp"
 
         try {
             mediaRecorder = MediaRecorder()
@@ -274,7 +275,7 @@ class ChatViewModel() : ViewModel() {
             mediaRecorder.setOutputFormat(MediaRecorder.OutputFormat.THREE_GPP)
             mediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB)
 
-            mediaRecorder.setOutputFile(audioPath)
+            mediaRecorder.setOutputFile(Uri.parse(audioPath).toString())
             mediaRecorder.prepare()
             mediaRecorder.start()
         } catch (e: Exception) {
@@ -296,14 +297,17 @@ class ChatViewModel() : ViewModel() {
         mediaRecorder.release()
     }
 
-    fun sendAudio(){
+    fun sendAudio(activity: ChatActivity, convID: String){
 
         // TODO: modify this implementation to adapt it for Firestore
-        val audioMessage = AudioMessage("Me", DateService.fromLocalDateTime(LocalDateTime.now()),
-            "Audio", audioPath)
+        Log.e("FIREBASE CHECK", Uri.fromFile(File(audioPath)).toString())
+        Log.e("FIREBASE CHECK", audioPath)
 
-        messages.add(audioMessage)
-        adapter.notifyItemInserted(messages.size - 1)
+        val audioMessage = AudioMessage("Me", DateService.fromLocalDateTime(LocalDateTime.now()),
+            "Audio", Uri.fromFile(File(audioPath)).toString(), audioPath
+        )
+        //Uri.fromFile(File(audioPath)).toString()
+        sendMessage(audioMessage, convID, activity)
     }
 
     // PERMISSIONS RELATED =======================================================

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -123,22 +123,17 @@
             app:srcCompat="@drawable/ic_baseline_send_24"
             android:visibility="gone"/>
 
-        <com.devlomi.record_view.RecordButton
+        <ImageButton
             android:id="@+id/recordButton"
-            android:layout_width="0dp"
-            android:layout_height="44dp"
-            android:layout_marginEnd="5dp"
-            android:layout_weight=".2"
-            android:background="@drawable/circle"
-            android:scaleType="center"
-            android:tint="@color/black"
+            android:layout_width="44dp"
+            android:layout_height="50dp"
+            android:backgroundTint="#FFFFFF"
+            android:contentDescription="@string/send"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:mic_icon="@drawable/ic_mic"
-            android:visibility="visible"
-            tools:ignore="TouchTargetSizeCheck,SpeakableTextPresentCheck">
-
-        </com.devlomi.record_view.RecordButton>
+            app:srcCompat="@drawable/ic_mic"
+            app:tint="#616161"
+            android:visibility="visible"/>
 
         <ImageButton
             android:id="@+id/buttonSendMessage"

--- a/app/src/test/java/com/github/brugapp/brug/MessageTest.kt
+++ b/app/src/test/java/com/github/brugapp/brug/MessageTest.kt
@@ -226,8 +226,9 @@ class MessageTest {
         ))
         val body = "TESTMESSAGE"
         val audioUrl = "/path/to/dummy/audio.mp3"
+        val audioPath = "/path/to/dummy/audio.mp3"
 
-        val m = AudioMessage(senderName, timestamp, body, audioUrl)
+        val m = AudioMessage(senderName, timestamp, body, audioUrl, audioPath)
 
         assertThat(m.senderName, IsEqual(senderName))
         assertThat(m.timestamp, IsEqual(timestamp))
@@ -246,8 +247,9 @@ class MessageTest {
         )
 
         val audioUrl = "/path/to/dummy/audio.mp3"
+        val audioPath = "/path/to/dummy/audio.mp3"
 
-        val m = AudioMessage.fromMessage(msg, audioUrl)
+        val m = AudioMessage.fromMessage(msg, audioUrl, audioPath)
 
         assertThat(m.senderName, IsEqual(msg.senderName))
         assertThat(m.timestamp, IsEqual(msg.timestamp))
@@ -263,9 +265,10 @@ class MessageTest {
         ))
         val body = "TESTMESSAGE"
         val audioUrl = "/path/to/dummy/audio.mp3"
+        val audioPath = "/path/to/dummy/audio.mp3"
 
-        val m1 = AudioMessage(senderName, timestamp, body, audioUrl)
-        val m2 = AudioMessage(senderName, timestamp, body, audioUrl)
+        val m1 = AudioMessage(senderName, timestamp, body, audioUrl, audioPath)
+        val m2 = AudioMessage(senderName, timestamp, body, audioUrl, audioPath)
 
         assertThat(m1, IsEqual(m2))
     }
@@ -281,9 +284,10 @@ class MessageTest {
         ))
         val body = "TESTMESSAGE"
         val audioUrl = "/path/to/dummy/audio.mp3"
+        val audioPath = "/path/to/dummy/audio.mp3"
 
-        val m1 = AudioMessage(senderName, timestamp1, body, audioUrl)
-        val m2 = AudioMessage(senderName, timestamp2, body, audioUrl)
+        val m1 = AudioMessage(senderName, timestamp1, body, audioUrl, audioPath)
+        val m2 = AudioMessage(senderName, timestamp2, body, audioUrl, audioPath)
 
         assertThat(m1, IsNot(IsEqual(m2)))
     }


### PR DESCRIPTION
This bug was related to the fact that the audio messages were stored on the external storage of the device (SD Card), which was okay in the case of the emulator, but for actual devices, not all of them have external storage.  